### PR TITLE
Optional Dependency: pChat, translation DE & fixes

### DIFF
--- a/XelosesContacts.txt
+++ b/XelosesContacts.txt
@@ -5,8 +5,8 @@
 ## Version: 1.0.2
 ## AddOnVersion: 10200
 ## APIVersion: 101044
-## DependsOn: LibAddonMenu-2.0>=37 LibSavedVars>=60005 LibExtendedJournal>=202010 LibCustomMenu>=722
-## OptionalDependsOn: LibChatMessage>=113 LibDebugLogger>=263 LibSlashCommander>=36 pChat>=10006010
+## DependsOn: LibAddonMenu-2.0>=37 LibSavedVars>=60005 LibCustomMenu>=722 LibExtendedJournal>=202010
+## OptionalDependsOn: LibChatMessage>=113 LibDebugLogger>=263 LibSlashCommander>=36
 ## SavedVariables: XelosesContactsData
 
 # DISCLAIMER:

--- a/XelosesContacts.txt
+++ b/XelosesContacts.txt
@@ -2,10 +2,10 @@
 ## Title: |cee55eeXeloses|r' Contacts
 ## Description: Unlimited Friends and Villains list with additional features.
 ## Author: |cee55eeXeloses|r (|c7799ee@Savaoth|r [PC/EU])
-## Version: 1.0.0
-## AddOnVersion: 10000
+## Version: 1.0.2
+## AddOnVersion: 10200
 ## APIVersion: 101044
-## DependsOn: LibAddonMenu-2.0>=36 LibSavedVars>=60005 LibExtendedJournal>=202010
+## DependsOn: LibAddonMenu-2.0>=37 LibSavedVars>=60005 LibExtendedJournal>=202010
 ## OptionalDependsOn: LibChatMessage>=113 LibDebugLogger>=263 LibSlashCommander>=36
 ## SavedVariables: XelosesContactsData
 

--- a/XelosesContacts.txt
+++ b/XelosesContacts.txt
@@ -5,8 +5,8 @@
 ## Version: 1.0.2
 ## AddOnVersion: 10200
 ## APIVersion: 101044
-## DependsOn: LibAddonMenu-2.0>=37 LibSavedVars>=60005 LibExtendedJournal>=202010
-## OptionalDependsOn: LibChatMessage>=113 LibDebugLogger>=263 LibSlashCommander>=36
+## DependsOn: LibAddonMenu-2.0>=37 LibSavedVars>=60005 LibExtendedJournal>=202010 LibCustomMenu>=722
+## OptionalDependsOn: LibChatMessage>=113 LibDebugLogger>=263 LibSlashCommander>=36 pChat>=10006010
 ## SavedVariables: XelosesContactsData
 
 # DISCLAIMER:

--- a/core/contextmenu.lua
+++ b/core/contextmenu.lua
@@ -45,15 +45,22 @@ end
 
 --Get the @displayName from the current chat message where one opened the player contextMenu (if pChat is loaded and
 --the pChat settings add the @displayName at the currently clicked chat message)
+local pChatData
 local function getPChatMessageDisplayName(player_name)
-    --As the XelosesContacts.txt adds an optional dependency to pChat, pChat's player contextmenu should be executed before
-    --XelosesContacts chat player contextmenu appears. Means: pChat will return the currently found displayName in the variable
+    --As the XelosesContacts.txt adds an optional dependency to pChat, pChat's player contextmenu (via LibCustomMenu) will be executed before
+    --XelosesContacts chat player contextmenu appears. Means: pChat will return the currently found displayName or characterName or displayName/characterName
+    --or whatever formatting the user chose in pChat already in LibCustomMenu's player context menu hook via variables player_name, raw_Name
+    --And in addition with pChat v10006020 in the variable
     --pChat.lastCheckDisplayNameData = { displayName=guildMemberOrFriendDisplayname, index=guildOrFriendIndexFound, isOnline=isOnline, type = "guild" or "friend"}
     -->This variable is currently only filled if the user activated pChat settings to add the "Teleport to" context menu entries
-    if pChat and pChat.lastCheckDisplayNameData then
-        return pChat.lastCheckDisplayNameData.displayName
+    if pChat then
+        pChatData = pChatData or pChat.pChatData
+
+        if pChat.lastCheckDisplayNameData then
+            return pChat.lastCheckDisplayNameData.displayName
+        end
     end
-    return player_name
+    return player_name --will be already @displayName or charactername, or @display/characterName etc. according to pChat's settings for the chat messages
 end
 
 function XC:SetupChatContextMenu()
@@ -74,6 +81,7 @@ function XC:SetupChatContextMenu()
    --Beartram 20250125 - Example how to use LibCustomMenu here
    --AddCustomMenuItem function accepts the same params as AddMenuItem, and LibCustomMenu supports submenus too (benefit) if needed
    local function chatPlayerContextMenuAddition(player_name, raw_Name)
+d("[XelosesContacts]PlayerContextMenuCallback-playerName: " ..tostring(player_name) ..", rawName: " .. tostring(raw_Name))
        player_name = getPChatMessageDisplayName(player_name)
        local target_name = XC:validateAccountName(player_name)
        if (target_name) then

--- a/core/contextmenu.lua
+++ b/core/contextmenu.lua
@@ -1,3 +1,4 @@
+local LCM   = LibCustomMenu
 local XC    = XelosesContacts
 local CONST = XC.CONST
 local L     = XC.getString
@@ -14,9 +15,12 @@ function XC:SetupContextMenus()
     self:SetupIgnoreListContextMenu()
 end
 
----@private
-function XC:createContactMenuItem(account_name, note, category)
-    if (self:isInContacts(account_name)) then return end
+-- --------------------
+--  @SECTION Menu item
+-- --------------------
+
+local function createContactMenuItem(account_name, note, category)
+    if (not account_name or self:isInContacts(account_name)) then return end
     local item = { name = L("MENU_ADD_CONTACT") }
     if (category) then
         if (category == CONST.CONTACTS_FRIENDS_ID) then
@@ -30,11 +34,19 @@ function XC:createContactMenuItem(account_name, note, category)
     return item
 end
 
+local function addContactContextMenuItem(data, category)
+    local target_name = XC:validateAccountName(data.displayName)
+    if (target_name) then
+        local menu_item = XC:createContactMenuItem(target_name, data.note, category)
+        if (menu_item) then return AddCustomMenuItem(menu_item.name, menu_item.callback) end
+    end
+end
+
 -- ----------------
 --  @SECTION Menus
 -- ----------------
 
-local function onSocilaListRowMouseUp(list, control, button, upInside, category)
+local function onSocialListRowMouseUp(list, control, button, upInside, category)
     if (button == MOUSE_BUTTON_INDEX_RIGHT and upInside) then
         local data = ZO_ScrollList_GetData(control)
         local menu_item = XC:createContactMenuItem(data.displayName, data.note, category)
@@ -43,87 +55,28 @@ local function onSocilaListRowMouseUp(list, control, button, upInside, category)
     end
 end
 
---Get the @displayName from the current chat message where one opened the player contextMenu (if pChat is loaded and
---the pChat settings add the @displayName at the currently clicked chat message)
-local pChatData
-local function getPChatMessageDisplayName(player_name)
-    --As the XelosesContacts.txt adds an optional dependency to pChat, pChat's player contextmenu (via LibCustomMenu) will be executed before
-    --XelosesContacts chat player contextmenu appears. Means: pChat will return the currently found displayName or characterName or displayName/characterName
-    --or whatever formatting the user chose in pChat already in LibCustomMenu's player context menu hook via variables player_name, raw_Name
-    --And in addition with pChat v10006020 in the variable
-    --pChat.lastCheckDisplayNameData = { displayName=guildMemberOrFriendDisplayname, index=guildOrFriendIndexFound, isOnline=isOnline, type = "guild" or "friend"}
-    -->This variable is currently only filled if the user activated pChat settings to add the "Teleport to" context menu entries
-    if pChat then
-        pChatData = pChatData or pChat.pChatData
-
-        if pChat.lastCheckDisplayNameData then
-            return pChat.lastCheckDisplayNameData.displayName
-        end
-    end
-    return player_name --will be already @displayName or charactername, or @display/characterName etc. according to pChat's settings for the chat messages
-end
-
 function XC:SetupChatContextMenu()
-    --[[
-    local ShowPlayerContextMenu = CHAT_SYSTEM.ShowPlayerContextMenu
-    CHAT_SYSTEM.ShowPlayerContextMenu = function(chat, player_name, raw_name)
-        local menu = ShowPlayerContextMenu(chat, player_name, raw_name)
-        local target_name = XC:validateAccountName(player_name)
-        if (target_name) then
-            local menu_item = XC:createContactMenuItem(target_name)
-            if (menu_item) then AddMenuItem(menu_item.name, menu_item.callback) end
-        end
-        ShowMenu(chat)
-        return menu
-    end
-   ]]
-
-   --Beartram 20250125 - Example how to use LibCustomMenu here
-   --AddCustomMenuItem function accepts the same params as AddMenuItem, and LibCustomMenu supports submenus too (benefit) if needed
-   local function chatPlayerContextMenuAddition(player_name, raw_Name)
-d("[XelosesContacts]PlayerContextMenuCallback-playerName: " ..tostring(player_name) ..", rawName: " .. tostring(raw_Name))
-       player_name = getPChatMessageDisplayName(player_name)
-       local target_name = XC:validateAccountName(player_name)
-       if (target_name) then
-           local menu_item = XC:createContactMenuItem(target_name)
-           if (menu_item) then
-               AddCustomMenuItem(menu_item.name, menu_item.callback)
-               ShowMenu() --shows at current MouseOverControl (where we right clicked)
-           end
-       end
-   end
-   LibCustomMenu:RegisterPlayerContextMenu(chatPlayerContextMenuAddition, LibCustomMenu.CATEGORY_LAST)
+    LCM:RegisterPlayerContextMenu(
+        function(player_name, raw_name)
+            return addContactContextMenuItem({ displayName = player_name })
+        end, 
+        LCM.CATEGORY_LAST
+    )
 end
 
 function XC:SetupGuildRosterContextMenu()
-    --Beartram 20250125 - Do not overwrite! Use LibCustomMenu API please!
-    local onMouseUp = GUILD_ROSTER_KEYBOARD.GuildRosterRow_OnMouseUp
-    GUILD_ROSTER_KEYBOARD.GuildRosterRow_OnMouseUp = function(list, control, button, upInside)
-        onMouseUp(list, control, button, upInside)
-        onSocilaListRowMouseUp(list, control, button, upInside)
-    end
+    LCM:RegisterGuildRosterContextMenu(addContactContextMenuItem, LCM.CATEGORY_LAST)
 end
 
 function XC:SetupGroupWindowContextMenu()
-    --Beartram 20250125 - Do not overwrite! Use LibCustomMenu API please!
-    local onMouseUp = GROUP_LIST.GroupListRow_OnMouseUp
-    GROUP_LIST.GroupListRow_OnMouseUp = function(list, control, button, upInside)
-        onMouseUp(list, control, button, upInside)
-        onSocilaListRowMouseUp(list, control, button, upInside)
-    end
+    LCM:RegisterGroupListContextMenu(addContactContextMenuItem, LCM.CATEGORY_LAST)
 end
 
 function XC:SetupFriendListContextMenu()
-    --Beartram 20250125 - Do not overwrite! Use LibCustomMenu API please!
-    local onMouseUp = FRIENDS_LIST.FriendsListRow_OnMouseUp
-    FRIENDS_LIST.FriendsListRow_OnMouseUp = function(list, control, button, upInside)
-        onMouseUp(list, control, button, upInside)
-        onSocilaListRowMouseUp(list, control, button, upInside, CONST.CONTACTS_FRIENDS_ID)
-    end
+    LCM:RegisterFriendsListContextMenu(addContactContextMenuItem, LCM.CATEGORY_LAST)
 end
 
 function XC:SetupIgnoreListContextMenu()
-    --Beartram 20250125 - Do not overwrite! Use LibCustomMenu API please!
     local onMouseUp = IGNORE_LIST.IgnoreListPanelRow_OnMouseUp
     IGNORE_LIST.IgnoreListPanelRow_OnMouseUp = function(list, control, button, upInside)
         onMouseUp(list, control, button, upInside)

--- a/core/contextmenu.lua
+++ b/core/contextmenu.lua
@@ -43,7 +43,21 @@ local function onSocilaListRowMouseUp(list, control, button, upInside, category)
     end
 end
 
+--Get the @displayName from the current chat message where one opened the player contextMenu (if pChat is loaded and
+--the pChat settings add the @displayName at the currently clicked chat message)
+local function getPChatMessageDisplayName(player_name)
+    --As the XelosesContacts.txt adds an optional dependency to pChat, pChat's player contextmenu should be executed before
+    --XelosesContacts chat player contextmenu appears. Means: pChat will return the currently found displayName in the variable
+    --pChat.lastCheckDisplayNameData = { displayName=guildMemberOrFriendDisplayname, index=guildOrFriendIndexFound, isOnline=isOnline, type = "guild" or "friend"}
+    -->This variable is currently only filled if the user activated pChat settings to add the "Teleport to" context menu entries
+    if pChat and pChat.lastCheckDisplayNameData then
+        return pChat.lastCheckDisplayNameData.displayName
+    end
+    return player_name
+end
+
 function XC:SetupChatContextMenu()
+    --[[
     local ShowPlayerContextMenu = CHAT_SYSTEM.ShowPlayerContextMenu
     CHAT_SYSTEM.ShowPlayerContextMenu = function(chat, player_name, raw_name)
         local menu = ShowPlayerContextMenu(chat, player_name, raw_name)
@@ -55,9 +69,26 @@ function XC:SetupChatContextMenu()
         ShowMenu(chat)
         return menu
     end
+   ]]
+
+   --Beartram 20250125 - Example how to use LibCustomMenu here
+   --AddCustomMenuItem function accepts the same params as AddMenuItem, and LibCustomMenu supports submenus too (benefit) if needed
+   local function chatPlayerContextMenuAddition(player_name, raw_Name)
+       player_name = getPChatMessageDisplayName(player_name)
+       local target_name = XC:validateAccountName(player_name)
+       if (target_name) then
+           local menu_item = XC:createContactMenuItem(target_name)
+           if (menu_item) then
+               AddCustomMenuItem(menu_item.name, menu_item.callback)
+               ShowMenu() --shows at current MouseOverControl (where we right clicked)
+           end
+       end
+   end
+   LibCustomMenu:RegisterPlayerContextMenu(chatPlayerContextMenuAddition, LibCustomMenu.CATEGORY_LAST)
 end
 
 function XC:SetupGuildRosterContextMenu()
+    --Beartram 20250125 - Do not overwrite! Use LibCustomMenu API please!
     local onMouseUp = GUILD_ROSTER_KEYBOARD.GuildRosterRow_OnMouseUp
     GUILD_ROSTER_KEYBOARD.GuildRosterRow_OnMouseUp = function(list, control, button, upInside)
         onMouseUp(list, control, button, upInside)
@@ -66,6 +97,7 @@ function XC:SetupGuildRosterContextMenu()
 end
 
 function XC:SetupGroupWindowContextMenu()
+    --Beartram 20250125 - Do not overwrite! Use LibCustomMenu API please!
     local onMouseUp = GROUP_LIST.GroupListRow_OnMouseUp
     GROUP_LIST.GroupListRow_OnMouseUp = function(list, control, button, upInside)
         onMouseUp(list, control, button, upInside)
@@ -74,6 +106,7 @@ function XC:SetupGroupWindowContextMenu()
 end
 
 function XC:SetupFriendListContextMenu()
+    --Beartram 20250125 - Do not overwrite! Use LibCustomMenu API please!
     local onMouseUp = FRIENDS_LIST.FriendsListRow_OnMouseUp
     FRIENDS_LIST.FriendsListRow_OnMouseUp = function(list, control, button, upInside)
         onMouseUp(list, control, button, upInside)
@@ -82,6 +115,7 @@ function XC:SetupFriendListContextMenu()
 end
 
 function XC:SetupIgnoreListContextMenu()
+    --Beartram 20250125 - Do not overwrite! Use LibCustomMenu API please!
     local onMouseUp = IGNORE_LIST.IgnoreListPanelRow_OnMouseUp
     IGNORE_LIST.IgnoreListPanelRow_OnMouseUp = function(list, control, button, upInside)
         onMouseUp(list, control, button, upInside)

--- a/lng/de.lua
+++ b/lng/de.lua
@@ -1,13 +1,10 @@
 local S = GetString
-
---Do not use ZO_CreateStringId for the same string constant twice! Use SafeAddString function and increase the version number by +1 instead. Described here:
---https://wiki.esoui.com/How_to_add_localization_support
-local _SAV = SafeAddString
+local _L = SafeAddString
 
 local function L(id, value, ...)
     local params = { ... }
     if (params and #params > 0) then value = string.format(value, ...) end
-    return _SAV(_G["XELCONTACTS_" .. tostring(id)], value, 2)
+    return _L(_G["XELCONTACTS_" .. tostring(id)], value, 2)
 end
 
 -- ============================
@@ -86,7 +83,7 @@ L("UI_DIALOG_CONTACT_ACCOUNT_NAME", "Kontoname:")
 L("UI_DIALOG_CONTACT_CATEGORY", "Typ:")
 L("UI_DIALOG_CONTACT_GROUP", "Gruppe:")
 L("UI_DIALOG_CONTACT_NOTE", "Persönliche Notiz:")
-L("UI_DIALOG_BUTTON_SAVE", "Speichern")
+L("UI_DIALOG_BUTTONE", "Speichern")
 
 -- Kontextmenü:
 L("MENU_ADD_CONTACT", "Zu Kontakten hinzufügen")
@@ -164,5 +161,5 @@ L("SLASHCMD_OPEN_SETTINGS_TOOLTIP", "AddOn-Einstellungsfenster öffnen")
 
 
 -- Keybinds:
-_SAV("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Kontakte öffnen", 2)
-_SAV("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Ziel zu Kontakten hinzufügen", 2)
+_L("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Kontakte öffnen", 2)
+_L("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Ziel zu Kontakten hinzufügen", 2)

--- a/lng/de.lua
+++ b/lng/de.lua
@@ -1,10 +1,10 @@
 local S = GetString
-local _L = SafeAddString
+local _L = function(id, value, version) return SafeAddString(id, value, version or 2) end
 
 local function L(id, value, ...)
     local params = { ... }
     if (params and #params > 0) then value = string.format(value, ...) end
-    return _L(_G["XELCONTACTS_" .. tostring(id)], value, 2)
+    return _L(_G["XELCONTACTS_" .. tostring(id)], value)
 end
 
 -- ===========================
@@ -160,7 +160,6 @@ L("SLASHCMD_NEW_CONTACT_TOOLTIP", "Dialogfeld \'Neuen Kontakt öffnen\'")
 L("SLASHCMD_ADD_CONTACT_TOOLTIP", "Neuen Kontakt hinzufügen")
 L("SLASHCMD_OPEN_SETTINGS_TOOLTIP", "AddOn-Einstellungsfenster öffnen")
 
-
 -- Keybinds:
-_L("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Kontakte öffnen", 2)
-_L("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Ziel zu Kontakten hinzufügen", 2)
+_L("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Kontakte öffnen")
+_L("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Ziel zu Kontakten hinzufügen")

--- a/lng/de.lua
+++ b/lng/de.lua
@@ -1,0 +1,168 @@
+local S = GetString
+
+--Do not use ZO_CreateStringId for the same string constant twice! Use SafeAddString function and increase the version number by +1 instead. Described here:
+--https://wiki.esoui.com/How_to_add_localization_support
+local _SAV = SafeAddString
+
+local function L(id, value, ...)
+    local params = { ... }
+    if (params and #params > 0) then value = string.format(value, ...) end
+    return _SAV(_G["XELCONTACTS_" .. tostring(id)], value, 2)
+end
+
+-- ============================
+-- === English localization ===
+-- ============================
+
+L("ALL", "Alle")
+L("DECLINED", "abgelehnt")
+L("WARNING", "WARNUNG!")
+L("ERROR", "FEHLER")
+
+-- Contact types:
+L("FRIENDS", "Freunde")
+L("FRIEND", "Freund")
+L("VILLAINS", "Schurken")
+L("VILLAIN", "Schurke")
+
+-- Contact groups (default):
+L("GROUP_11", "Freund")
+L("GROUP_12", "Teamkollege")
+L("GROUP_13", "Häuser")
+L("GROUP_14", "Service")
+L("GROUP_15", "Rollenspiel")
+
+L("GROUP_21", "Feind")
+L("GROUP_22", "Toxisch")
+L("GROUP_23", "Spammer")
+L("GROUP_24", "Cheater")
+L("GROUP_25", "Unfug")
+
+-- Group roles:
+L("DPS", "DPS")
+L("TANK", "Tank")
+L("HEAL", "Heiler")
+
+-- Notifications and Warnings:
+L("CONTACT_ADDED", "Spieler <<LINK>> wurde zu den Kontakten hinzugefügt.")
+L("CONTACT_REMOVED", "Kontakt <<1>> wurde entfernt.")
+L("TARGET_IN_CONTACTS", "Zielspieler <<LINK>> bereits in den Kontakten.")
+L("CHAT_WHISPER_BLOCKED", "<<LINK>> ist ein <<ICON>><<GROUP>>. Chat ist für diese Gruppe von Schurken gesperrt.")
+L("GROUP_WITH_VILLAIN", "Du bist einer Gruppe mit <<ICON>><<GROUP>> <<LINK>> beigetreten!")
+L("GROUP_JOINED_VILLAIN", "<<ICON>><<GROUP>> <<LINK>> ist deiner Gruppe beigetreten!")
+L("FRIEND_INVITE_FROM_VILLAIN", "<<ICON>><<GROUP>> <<LINK>> bittet um Freundschaft!")
+L("GROUP_INVITE_FROM_VILLAIN", "<<ICON>><<GROUP>> <<NAME>> lädt dich zu seiner Gruppe ein!")
+L("CONFIRM_CONTACT_ADD", "Möchtest du Spieler <<1>> wirklich zu den Kontakten hinzufügen?")
+L("CONFIRM_CONTACT_REMOVE", "Möchtest du <<1>> wirklich aus den Kontakten entfernen?")
+L("CONFIRM_INVITE_VILLAIN", "Möchtest du <<2>> <<1>> wirklich zur Gruppe einladen?")
+L("CONFIRM_INVITE_VILLAIN_WARNING", "Bösewicht wird der Gruppe hinzugefügt!")
+L("CONFIRM_BEFRIEND_VILLAIN", "Möchtest du <<2>> <<1>> wirklich zu den Freunden hinzufügen?")
+L("CONFIRM_BEFRIEND_VILLAIN_WARNING", "Bösewicht wird den Freunden hinzugefügt!")
+L("CONFIRM_IMPORT_FRIENDS", "Möchten Sie wirklich alle ESO-Freunde im Spiel in die Kontakte importieren?")
+L("CONFIRM_IMPORT_IGNORED", "Möchten Sie wirklich alle ignorierten ESO-Spieler im Spiel in die Kontakte importieren?")
+L("CONFIRM_IMPORT_NAMEZ", "Möchten Sie wirklich alle Freunde und Feinde aus dem Namez AddOn in die Kontakte importieren?")
+L("NOTIFY_IMPORT_COMPLETED", "Import abgeschlossen.\n\n<<1>> neue Kontakte hinzugefügt.")
+
+-- UI/Liste:
+L("UI_TITLE", "Kontakte")
+L("UI_TITLE_SUB", "Freunde und Schurken")
+L("UI_INFO_NO_CONTACTS", "Sie haben keine Kontakte.")
+L("UI_INFO_NO_CONTACTS_FOUND", "Keine Kontakte gefunden.")
+L("UI_HEADER_ACCOUNT", "Konto")
+L("UI_HEADER_GROUP", "Gruppe")
+L("UI_HEADER_NOTE", "Hinweis")
+L("UI_HEADER_TIMESTAMP", "Hinzugefügt")
+L("UI_BTN_ADD_CONTACT_TOOLTIP", "Neuen Kontakt hinzufügen")
+L("UI_BTN_OPEN_SETTINGS_TOOLTIP", "AddOn Einstellungen öffnen")
+L("UI_BTN_SEARCH_RESET_TOOLTIP", "Suche zurücksetzen")
+L("UI_CONTACTS_COUNT", "Kontakte insgesamt: %d Freund(e) und %d Bösewicht(e).")
+L("UI_FILTERED_CONTACTS_COUNT", "%d Kontakt(e) gefunden).")
+
+-- UI/Dialog:
+L("UI_DIALOG_TITLE_ADD_CONTACT", "Neuen Kontakt hinzufügen Kontakt")
+L("UI_DIALOG_TITLE_EDIT_CONTACT", "Kontakt bearbeiten")
+L("UI_BTN_EDIT_ACCOUNT_NAME_TOOLTIP", "Kontonamen bearbeiten")
+L("UI_DIALOG_CONTACT_ACCOUNT_NAME", "Kontoname:")
+L("UI_DIALOG_CONTACT_CATEGORY", "Typ:")
+L("UI_DIALOG_CONTACT_GROUP", "Gruppe:")
+L("UI_DIALOG_CONTACT_NOTE", "Persönliche Notiz:")
+L("UI_DIALOG_BUTTON_SAVE", "Speichern")
+
+-- Kontextmenü:
+L("MENU_ADD_CONTACT", "Zu Kontakten hinzufügen")
+L("MENU_EDIT_CONTACT", "Kontakt bearbeiten")
+L("MENU_REMOVE_CONTACT", "Aus Kontakten entfernen")
+
+-- Einstellungen:
+L("SETTINGS_GENERAL", "Allgemein")
+L("SETTINGS_UI_SEARCH_NOTE", "Suche nach persönlichen Notizen des Kontakts zulassen")
+L("SETTINGS_UI_SEARCH_NOTE_TOOLTIP", "Kontakte nach Kontonamen und persönlichen Notizen in der Kontaktliste suchen. Schalten Sie diese Einstellung AUS, um nur nach dem Kontonamen zu suchen.")
+L("SETTINGS_COLORS", "Farben")
+L("SETTINGS_COLORS_DESCRIPTION", "Hervorhebungsfarben für Kontakte.")
+L("SETTINGS_COLOR", "<<1>> Farbe")
+L("SETTINGS_NOTIFICATION", "Benachrichtigungen und Warnungen")
+L("SETTINGS_NOTIFICATION_DESCRIPTION", "Bildschirm- und Chat-Benachrichtigungen/Warnungen für Kontakte.")
+L("SETTINGS_NOTIFICATION_CHANNEL", "Kanal für Benachrichtigungen und Infonachrichten")
+L("SETTINGS_NOTIFICATION_CHANNEL_TOOLTIP", "Wohin Benachrichtigungen und Infonachrichten gesendet werden sollen.")
+L("SETTINGS_NOTIFICATION_CHANNEL_OPTION_BOTH", "Beide (Chat+Bildschirm)")
+L("SETTINGS_NOTIFICATION_CHANNEL_OPTION_CHAT", "Chat")
+L("SETTINGS_NOTIFICATION_CHANNEL_OPTION_SCREEN", "Bildschirm")
+L("SETTINGS_NOTIFICATION_GROUP_JOIN", "Warnung anzeigen, wenn einer Gruppe mit Bösewicht beigetreten wird")
+L("SETTINGS_NOTIFICATION_GROUP_JOIN_TOOLTIP", "Warnung anzeigen (hängt von der Auswahl oben ab), wenn einer Gruppe mit Bösewicht beigetreten wird.")
+L("SETTINGS_NOTIFICATION_GROUP_JOIN_SCREEN", "Warnung auf dem Bildschirm, wenn einer Gruppe mit Bösewicht beigetreten wird")
+L("SETTINGS_NOTIFICATION_GROUP_JOIN_SCREEN_TOOLTIP", "Große Warnung in der Mitte des Bildschirms anzeigen, wenn einer Gruppe mit Bösewicht beigetreten wird Bösewicht.")
+L("SETTINGS_NOTIFICATION_GROUP_MEMBER", "Warnung anzeigen, wenn Bösewicht Ihrer Gruppe beigetreten ist.")
+L("SETTINGS_NOTIFICATION_GROUP_MEMBER_TOOLTIP", "Warnung anzeigen (hängt von der Auswahl oben ab), wenn Bösewicht Ihrer Gruppe beigetreten ist.")
+L("SETTINGS_NOTIFICATION_GROUP_MEMBER_SCREEN", "Warnung auf dem Bildschirm anzeigen, wenn Bösewicht Ihrer Gruppe beigetreten ist.")
+L("SETTINGS_NOTIFICATION_GROUP_MEMBER_SCREEN_TOOLTIP", "Große Warnung in der Mitte des Bildschirms anzeigen, wenn Bösewicht Ihrer Gruppe beigetreten ist.")
+L("SETTINGS_NOTIFICATION_GROUP_INVITE", "Warnung anzeigen, wenn Bösewicht Sie zur Gruppe einlädt.")
+L("SETTINGS_NOTIFICATION_GROUP_INVITE_TOOLTIP", "Warnung anzeigen (hängt von der Auswahl oben ab), wenn Bösewicht Sie zur Gruppe einlädt. Gruppe.")
+L("SETTINGS_NOTIFICATION_GROUP_INVITE_SCREEN", "Warnung auf dem Bildschirm, wenn der Bösewicht Sie zur Gruppe einlädt")
+L("SETTINGS_NOTIFICATION_GROUP_INVITE_SCREEN_TOOLTIP", "Große Warnung in der Mitte des Bildschirms anzeigen, wenn der Bösewicht Sie zur Gruppe einlädt.")
+L("SETTINGS_NOTIFICATION_FRIEND_INVITE", "Warnung anzeigen, wenn Freundschaftsanfrage vom Bösewicht empfangen wird")
+L("SETTINGS_NOTIFICATION_FRIEND_INVITE_TOOLTIP", "Warnung anzeigen (hängt von der Auswahl oben ab), wenn Freundschaftsanfrage vom Bösewicht empfangen wird.")
+L("SETTINGS_NOTIFICATION_FRIEND_INVITE_SCREEN", "Warnung auf dem Bildschirm, wenn Freundschaftsanfrage von Bösewicht empfangen wird")
+L("SETTINGS_NOTIFICATION_FRIEND_INVITE_SCREEN_TOOLTIP", "Warnung in der Mitte des Bildschirms anzeigen, wenn Freundschaftsanfrage von Bösewicht empfangen wird.")
+L("SETTINGS_AUTODECLINE_FRIEND_INVITE", "Freundschaftseinladungen von Bösewichten automatisch ablehnen")
+L("SETTINGS_AUTODECLINE_FRIEND_INVITE_TOOLTIP", "Freundschaftseinladungen automatisch ablehnen, wenn der Einladende ein Bösewicht ist.")
+L("SETTINGS_AUTODECLINE_GROUP_INVITE", "Gruppeneinladungen von Bösewichten automatisch ablehnen")
+L("SETTINGS_AUTODECLINE_GROUP_INVITE_TOOLTIP", "Gruppeneinladungen automatisch ablehnen, wenn der Einladende ein Bösewicht.")
+L("SETTINGS_CONFIRM_ADD_FRIEND", "Hinzufügen von Bösewicht als Freund bestätigen")
+L("SETTINGS_CONFIRM_ADD_FRIEND_TOOLTIP", "Bestätigungsdialog anzeigen, wenn versucht wird, Bösewicht zu den ESO-Freunden im Spiel hinzuzufügen.")
+L("SETTINGS_CHAT", "Chat")
+L("SETTINGS_CHAT_DESCRIPTION", "Chat-Einstellungen.")
+L("SETTINGS_CHAT_BLOCK", "Chat-Blockierung")
+L("SETTINGS_CHAT_BLOCK_GROUPS", "Gruppen")
+L("SETTINGS_CHAT_BLOCK_GROUPS_DESCRIPTION", "Chat-Blockierung für Bösewichte pro Gruppe einrichten.")
+L("SETTINGS_CHAT_BLOCK_GROUP", "Chat für Kategorie <<1>> (<<2>>) blockieren")
+L("SETTINGS_CHAT_BLOCK_GROUP_TOOLTIP", "Chat blockieren Nachrichten aus dieser Schurkengruppe.")
+L("SETTINGS_CHAT_BLOCK_CHANNELS", "Chatkanäle")
+L("SETTINGS_CHAT_BLOCK_CHANNELS_DESCRIPTION", "Chatkanäle zum Blockieren von Nachrichten von Schurken einrichten (nur Nachrichten aus den oben ausgewählten Schurkenkategorien werden blockiert).")
+L("SETTINGS_CHAT_BLOCK_CHANNEL_SAY", "%s, %s, %s", S(SI_CHAT_CHANNEL_NAME_SAY), S(SI_CHAT_CHANNEL_NAME_YELL), S(SI_CHAT_CHANNEL_NAME_EMOTE))
+L("SETTINGS_CHAT_BLOCK_CHANNEL_ZONE", S(SI_CHAT_CHANNEL_NAME_ZONE))
+L("SETTINGS_CHAT_BLOCK_CHANNEL_GROUP", S(SI_CHAT_CHANNEL_NAME_PARTY))
+L("SETTINGS_CHAT_BLOCK_CHANNEL_GUILD", "Gilde und Gildenoffizier")
+L("SETTINGS_CHAT_BLOCK_CHANNEL_WHISPER", S(SI_CHAT_CHANNEL_NAME_WHISPER))
+L("SETTINGS_CHAT_BLOCK_CHANNEL_TOOLTIP", "Chatnachrichten von Schurken in diesem Kanal blockieren.")
+L("SETTINGS_CHAT_INFO", "Keine Informationsnachrichten im Chat drucken")
+L("SETTINGS_CHAT_INFO_TOOLTIP", "Keine Informationsnachrichten ('Kontakt hinzugefügt', 'Kontakt entfernt' usw.) im Chat drucken.")
+L("SETTINGS_GROUPS", "Gruppen")
+L("SETTINGS_GROUPS_DESCRIPTION", "Kontaktgruppen bearbeiten.")
+L("SETTINGS_GROUP_NAME", "Gruppe <<1>> Name:")
+L("SETTINGS_IMPORT", "Importieren")
+L("SETTINGS_IMPORT_DESCRIPTION", "Freunde und Bösewichte aus der ESO-Freundesliste und der Ignorierten-Liste im Spiel importieren.")
+L("SETTINGS_IMPORT_BUTTON", "Importieren")
+L("SETTINGS_IMPORT_DESTINATION", "Zur Gruppe hinzufügen:")
+L("SETTINGS_IMPORT_DESTINATION_TOOLTIP", "Spieler in ausgewählte Gruppe importieren.")
+L("SETTINGS_IMPORT_FRIENDS", "ESO-Freunde im Spiel in Kontakte importieren.")
+L("SETTINGS_IMPORT_IGNORED", "ESO-Ignorierte Spieler im Spiel in Kontakte importieren.")
+
+-- Slash commands:
+L("SLASHCMD_NEW_CONTACT_TOOLTIP", "Dialogfeld \'Neuen Kontakt öffnen\'")
+L("SLASHCMD_ADD_CONTACT_TOOLTIP", "Neuen Kontakt hinzufügen")
+L("SLASHCMD_OPEN_SETTINGS_TOOLTIP", "AddOn-Einstellungsfenster öffnen")
+
+
+-- Keybinds:
+_SAV("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Kontakte öffnen", 2)
+_SAV("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Ziel zu Kontakten hinzufügen", 2)

--- a/lng/de.lua
+++ b/lng/de.lua
@@ -7,9 +7,10 @@ local function L(id, value, ...)
     return _L(_G["XELCONTACTS_" .. tostring(id)], value, 2)
 end
 
--- ============================
--- === English localization ===
--- ============================
+-- ===========================
+-- === German localization ===
+-- ===========================
+-- by Baertram (https://www.esoui.com/forums/member.php?userid=2028)
 
 L("ALL", "Alle")
 L("DECLINED", "abgelehnt")

--- a/lng/default.lua
+++ b/lng/default.lua
@@ -1,10 +1,10 @@
 local S = GetString
-local _L = ZO_CreateStringId --This will add the String constant with version = 1, so the other language files should add version 2 or higher to overwrite it via function SafeAddString
+local _L = function(id, value, version) return SafeAddString(id, value, version or 2) end
 
 local function L(id, value, ...)
     local params = { ... }
     if (params and #params > 0) then value = string.format(value, ...) end
-    return _L("XELCONTACTS_" .. id, value)
+    return _L(_G["XELCONTACTS_" .. tostring(id)], value)
 end
 
 -- ============================

--- a/lng/default.lua
+++ b/lng/default.lua
@@ -1,10 +1,10 @@
 local S = GetString
-local _L = function(id, value, version) return SafeAddString(id, value, version or 2) end
+local _L = ZO_CreateStringId
 
 local function L(id, value, ...)
     local params = { ... }
     if (params and #params > 0) then value = string.format(value, ...) end
-    return _L(_G["XELCONTACTS_" .. tostring(id)], value)
+    return _L("XELCONTACTS_" .. id, value)
 end
 
 -- ============================

--- a/lng/default.lua
+++ b/lng/default.lua
@@ -1,5 +1,5 @@
 local S = GetString
-local _L = ZO_CreateStringId
+local _L = ZO_CreateStringId --This will add the String constant with version = 1, so the other language files should add version 2 or higher to overwrite it via function SafeAddString
 
 local function L(id, value, ...)
     local params = { ... }

--- a/lng/ru.lua
+++ b/lng/ru.lua
@@ -1,13 +1,10 @@
 local S = GetString
-
---Do not use ZO_CreateStringId for the same string constant twice! Use SafeAddString function and increase the version number by +1 instead. Described here:
---https://wiki.esoui.com/How_to_add_localization_support
-local _SAV = SafeAddString
+local _L = function(id, value, version) return SafeAddString(id, value, version or 2) end
 
 local function L(id, value, ...)
     local params = { ... }
     if (params and #params > 0) then value = string.format(value, ...) end
-    return _SAV(_G["XELCONTACTS_" .. tostring(id)], value, 2)
+    return _L(_G["XELCONTACTS_" .. tostring(id)], value)
 end
 
 -- ============================
@@ -163,5 +160,5 @@ L("SLASHCMD_ADD_CONTACT_TOOLTIP", "Добавить в контакты")
 L("SLASHCMD_OPEN_SETTINGS_TOOLTIP", "Открыть настройки аддона")
 
 -- Keybinds:
-_SAV("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Список контактов", 2)
-_SAV("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Добавить цель в Контакты", 2)
+_SAV("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Список контактов")
+_SAV("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Добавить цель в Контакты")

--- a/lng/ru.lua
+++ b/lng/ru.lua
@@ -1,10 +1,13 @@
 local S = GetString
-local _L = ZO_CreateStringId
+
+--Do not use ZO_CreateStringId for the same string constant twice! Use SafeAddString function and increase the version number by +1 instead. Described here:
+--https://wiki.esoui.com/How_to_add_localization_support
+local _SAV = SafeAddString
 
 local function L(id, value, ...)
     local params = { ... }
     if (params and #params > 0) then value = string.format(value, ...) end
-    return _L("XELCONTACTS_" .. id, value)
+    return _SAV(_G["XELCONTACTS_" .. tostring(id)], value, 2)
 end
 
 -- ============================
@@ -160,5 +163,5 @@ L("SLASHCMD_ADD_CONTACT_TOOLTIP", "Добавить в контакты")
 L("SLASHCMD_OPEN_SETTINGS_TOOLTIP", "Открыть настройки аддона")
 
 -- Keybinds:
-_L("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Список контактов")
-_L("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Добавить цель в Контакты")
+_SAV("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Список контактов", 2)
+_SAV("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Добавить цель в Контакты", 2)

--- a/lng/ru.lua
+++ b/lng/ru.lua
@@ -160,5 +160,5 @@ L("SLASHCMD_ADD_CONTACT_TOOLTIP", "Добавить в контакты")
 L("SLASHCMD_OPEN_SETTINGS_TOOLTIP", "Открыть настройки аддона")
 
 -- Keybinds:
-_SAV("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Список контактов")
-_SAV("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Добавить цель в Контакты")
+_L("SI_BINDING_NAME_XELCONTACTS_UI_SHOW", "Список контактов")
+_L("SI_BINDING_NAME_XELCONTACTS_ADD_CONTACT", "Добавить цель в Контакты")


### PR DESCRIPTION
Please check the comments at translation files default.lua, ru.lua and de.lu
and at the core/contextmenu.lua -> Use LibCustomMenu please to hook into the contextmenus and make it compatible with other addons! Do not overwrite ZOs functions, never, if you can either ZO_PreHook or SecurePostHook them.
Only if there is no other way than overwriting, you might do it, and then always make sure to overwrite the class functions at ZO_* and not the object functions created from that classes (e.g. overwrite ZO_Smithing.SetMode instead if SMITHING.SetMode) to make all addons work in combination properly.

I've updated pChat on my github repo: https://github.com/Baertram/pChat
Please download and test with it, version 10006020